### PR TITLE
MO adjustements

### DIFF
--- a/src/tequila/quantumchemistry/psi4_interface.py
+++ b/src/tequila/quantumchemistry/psi4_interface.py
@@ -317,14 +317,16 @@ class QuantumChemistryPsi4(QuantumChemistryBase):
         return h
 
     def compute_two_body_integrals(self, ref_wfn=None):
-        # For two-body integrals, we use the usual chemistry convention
-        # < rs | O(1,2) | pq > = int r(1)* s(2)* O(1,2) p(1) q(2),
-        # while here, O(1,2) = g12 = 1/r12.
-        # Then, the 2-bdy terms become sum_{pqrs} h^pq_rs a^pq_rs,
-        # where a^pq_rs = a^p a^q a_s a_r
-        # Psi4 uses int p(1) q(1) g12 r(2) s(2) (only real orbitals)
-        # Due to the 8-fold symmetry for real orbs,
-        # we can e.g. reorder according to 'psqr -> pqrs'
+        """
+          For two-body integrals, we use the usual chemistry convention
+        < rs | O(1,2) | pq > = int r(1)* s(2)* O(1,2) p(1) q(2),
+        while here, O(1,2) = g12 = 1/r12.
+          Then, the 2-bdy terms become sum_{pqrs} h^pq_rs a^pq_rs,
+        where a^pq_rs = a^p a^q a_s a_r
+          Psi4 uses int p(1) q(1) g12 r(2) s(2) (only real orbitals)
+        Due to the 8-fold symmetry for real orbs,
+        we can e.g. reorder according to 'psqr -> pqrs'
+        """
         if ref_wfn is None:
             if 'hf' not in self.logs:
                 self.compute_energy(method="hf")

--- a/src/tequila/quantumchemistry/psi4_interface.py
+++ b/src/tequila/quantumchemistry/psi4_interface.py
@@ -318,14 +318,14 @@ class QuantumChemistryPsi4(QuantumChemistryBase):
 
     def compute_two_body_integrals(self, ref_wfn=None):
         """
-          For two-body integrals, we use the usual chemistry convention
+          For two-body integrals, we use the usual convention
         < rs | O(1,2) | pq > = int r(1)* s(2)* O(1,2) p(1) q(2),
         while here, O(1,2) = g12 = 1/r12.
           Then, the 2-bdy terms become sum_{pqrs} h^pq_rs a^pq_rs,
         where a^pq_rs = a^p a^q a_s a_r
-          Psi4 uses int p(1) q(1) g12 r(2) s(2) (only real orbitals)
-        Due to the 8-fold symmetry for real orbs,
-        we can e.g. reorder according to 'psqr -> pqrs'
+          Psi4 uses int p(1) q(1) g12 r(2) s(2) (only real orbitals).
+        To assimilate this to our ordering,
+        we can e.g. reorder according to 'prqs -> pqrs'.
         """
         if ref_wfn is None:
             if 'hf' not in self.logs:
@@ -342,7 +342,7 @@ class QuantumChemistryPsi4(QuantumChemistryBase):
         # Molecular orbitals (coeffs)
         Ca = wfn.Ca()
         h = numpy.asarray(mints.mo_eri(Ca, Ca, Ca, Ca))
-        h = numpy.einsum("psqr -> pqrs", h, optimize='greedy')
+        h = numpy.einsum("prqs -> pqrs", h, optimize='greedy')
         return h
 
     def compute_ccsd_amplitudes(self):

--- a/src/tequila/quantumchemistry/qc_base.py
+++ b/src/tequila/quantumchemistry/qc_base.py
@@ -242,7 +242,7 @@ class Amplitudes:
         -------
 
         """
-        tijab = cs.tIjAb - numpy.einsum("ijab -> ijba", cs.tIjAb, optimize='optimize')
+        tijab = cs.tIjAb - numpy.einsum("ijab -> ijba", cs.tIjAb, optimize='greedy')
         return cls(tIjAb=cs.tIjAb, tIA=cs.tIA, tiJaB=cs.tIjAb, tia=cs.tIA, tijab=tijab, tIJAB=tijab)
 
     tIjAb: numpy.ndarray = None
@@ -779,10 +779,10 @@ class QuantumChemistryBase:
         amplitudes = abgij * 1.0 / (
                 ei.reshape(1, 1, -1, 1) + ei.reshape(1, 1, 1, -1) - ai.reshape(-1, 1, 1, 1) - ai.reshape(1, -1, 1, 1))
         E = 2.0 * numpy.einsum('abij,abij->', amplitudes, abgij) - numpy.einsum('abji,abij', amplitudes, abgij,
-                                                                                optimize='optimize')
+                                                                                optimize='greedy')
 
         self.molecule.mp2_energy = E + self.molecule.hf_energy
-        return ClosedShellAmplitudes(tIjAb=numpy.einsum('abij -> ijab', amplitudes, optimize='optimize'))
+        return ClosedShellAmplitudes(tIjAb=numpy.einsum('abij -> ijab', amplitudes, optimize='greedy'))
 
     def compute_cis_amplitudes(self):
         """

--- a/src/tequila/quantumchemistry/qc_base.py
+++ b/src/tequila/quantumchemistry/qc_base.py
@@ -298,6 +298,106 @@ class Amplitudes:
         return variables
 
 
+@dataclass
+class TwoBodyTensor:
+    """
+    Convenience class for reordering of two-body tensors
+    """
+    hPQrs: numpy.ndarray = None
+    # default ordering is 'chem', assumes that we get data from psi4
+    scheme: str = 'chem'
+
+    def is_openfermion(self) -> bool:
+        """
+        Checks whether current ordering scheme is 'openfermion'
+        """
+        if self.scheme == 'openfermion' or self.scheme == 'of':
+            return True
+        else:
+            return False
+
+    def is_chem(self) -> bool:
+        """
+        Checks whether current ordering scheme is 'chem'
+        """
+        if self.scheme == 'chem' or self.scheme == 'c':
+            return True
+        else:
+            return False
+
+    def is_phys(self) -> bool:
+        """
+        Checks whether current ordering scheme is 'phys'
+        """
+        if self.scheme == 'phys' or self.scheme == 'p':
+            return True
+        else:
+            return False
+
+    def reorder(self, to: str = 'of'):
+        """
+        Function to reorder tensors according to some convention
+
+        Parameters
+        ----------
+
+        to :
+            Ordering scheme of choice.
+            'openfermion', 'of' (default) :
+                openfermion - ordering, corresponds to integrals of the type
+                h^pq_rs = int p(1)* q(2)* O(1,2) r(2) s(1) (O(1,2)
+                with operators a^pq_rs = a^p a^q a_r a_s (a^p == a^dagger_p)
+                currently needed for dependencies on openfermion-library
+            'chem', 'c' :
+                quantum chemistry ordering, collect particle terms,
+                more convenient for real-space methods
+                h^pq_rs = int p(1) q(1) O(1,2) r(2) s(2)
+                This is output by psi4
+            'phys', 'p' :
+                typical physics ordering, integrals of type
+                h^pq_rs = int p(1)* q(2)* O(1,2) r(1) s(2)
+                with operators a^pq_rs = a^p a^q a_s a_r
+
+            Returns
+            -------
+            type
+                the two-body tensors in chosen ordering (openfermion per default)
+        """
+        to = to.lower()
+
+        if self.is_chem():
+            if to == 'chem' or to == 'c':
+                pass
+            elif to == 'openfermion' or to == 'of':
+                self.hPQrs = numpy.einsum("psqr -> pqrs", self.hPQrs, optimize='greedy')
+                self.scheme = 'openfermion'
+            elif to == 'phys' or to == 'p':
+                self.hPQrs = numpy.einsum("prqs -> pqrs", self.hPQrs, optimize='greedy')
+                self.scheme = 'phys'
+        elif self.is_openfermion():
+            if to == 'chem' or to == 'c':
+                self.hPQrs = numpy.einsum("pqrs -> psqr", self.hPQrs, optimize='greedy')
+                self.scheme = 'chem'
+            elif to == 'openfermion' or to == 'of':
+                pass
+            elif to == 'phys' or to == 'p':
+                self.hPQrs = numpy.einsum("pqrs -> pqsr", self.hPQrs, optimize='greedy')
+                self.scheme = 'phys'
+        elif self.is_phys():
+            if to == 'chem' or to == 'c':
+                self.hPQrs = numpy.einsum("pqrs -> prqs", self.hPQrs, optimize='greedy')
+                self.scheme = 'chem'
+            elif to == 'openfermion' or to == 'of':
+                self.hPQrs = numpy.einsum("pqsr -> pqrs", self.hPQrs, optimize='greedy')
+                self.scheme = 'openfermion'
+            elif to == 'phys' or to == 'p':
+                pass
+
+    def get_hPQrs(self) -> numpy.ndarray:
+        """ """
+        return self.hPQrs
+
+
 class QuantumChemistryBase:
     """ """
 
@@ -772,7 +872,7 @@ class QuantumChemistryBase:
         assert self.parameters.closed_shell
         g = self.molecule.two_body_integrals
         fij = self.molecule.orbital_energies
-        nocc = self.molecule.n_electrons // 2 # this is never the active space
+        nocc = self.molecule.n_electrons // 2  # this is never the active space
         ei = fij[:nocc]
         ai = fij[nocc:]
         abgij = g[nocc:, nocc:, :nocc, :nocc]


### PR DESCRIPTION
- changed numpy.einsum optimize to greedy
- changed computation of electr. rep. integrals in psi4_interface to molecular integrals
- added class TwoBodyTensor for convenient reordering between openfermion, chemistry and physics convention. This class also can easily be extended for some functionalities needed in expl. corrl. correction scheme, or be of use if dependency on openfermion would be attenuated.