### PR TITLE
Significantly improved the run times of the test suite

### DIFF
--- a/tests/test_gd_optimizer.py
+++ b/tests/test_gd_optimizer.py
@@ -49,8 +49,10 @@ def test_method_convergence(simulator,method):
     H = tq.paulis.X(0)
     O = tq.ExpectationValue(U=U, H=H)
     samples=None
-    angles={'a':numpy.pi/3}
-    result = minimize(objective=O, method=method,initial_values=angles, samples=samples, lr=0.1,maxiter=200, backend=simulator)
+    angles={'a':-1.15}
+    result = minimize(objective=O, method=method,
+                      initial_values=angles, samples=samples,
+                      lr=0.1,maxiter=20, backend=simulator, silent=False)
     assert (numpy.isclose(result.energy, -1.0,atol=3.e-2))
 
 @pytest.mark.parametrize("simulator", simulators)
@@ -64,13 +66,11 @@ def test_methods_qng(simulator, method):
     U += tq.gates.Ry('c',1) +tq.gates.Rx('d',2)
     U += tq.gates.CNOT(control=0,target=1)+tq.gates.CNOT(control=1,target=2)
     E = tq.ExpectationValue(H=H, U=U)
-    # just equal to the original circuit, but i'm checking that all the sub-division works
-    O=E
-    initial_values = {"a": 0.432, "b": -0.123, 'c':0.543,'d':0.233}
+    initial_values = {"a": -0.01, "b": 1.60, 'c': 1.4, 'd': -0.53}
 
     lr=0.1
-    result = minimize(objective=-O,gradient='qng',backend=simulator,
-                                         method=method, maxiter=200,lr=lr,
+    result = minimize(objective=-E,gradient='qng',backend=simulator,
+                                         method=method, maxiter=20,lr=lr,
                                          initial_values=initial_values, silent=False)
     assert(numpy.isclose(result.energy, -0.612, atol=2.e-2))
 

--- a/tests/test_gd_optimizer.py
+++ b/tests/test_gd_optimizer.py
@@ -52,7 +52,7 @@ def test_method_convergence(simulator,method):
     angles={'a':-1.15}
     result = minimize(objective=O, method=method,
                       initial_values=angles, samples=samples,
-                      lr=0.1,maxiter=20, backend=simulator, silent=False)
+                      lr=0.1,maxiter=20, backend=simulator, silent=True)
     assert (numpy.isclose(result.energy, -1.0,atol=3.e-2))
 
 @pytest.mark.parametrize("simulator", simulators)
@@ -71,6 +71,6 @@ def test_methods_qng(simulator, method):
     lr=0.1
     result = minimize(objective=-E,gradient='qng',backend=simulator,
                                          method=method, maxiter=20,lr=lr,
-                                         initial_values=initial_values, silent=False)
+                                         initial_values=initial_values, silent=True)
     assert(numpy.isclose(result.energy, -0.612, atol=2.e-2))
 

--- a/tests/test_gpyopt.py
+++ b/tests/test_gpyopt.py
@@ -75,5 +75,6 @@ def test_one_qubit_shot(simulator):
     U = tq.gates.Trotterized(angles=["a"], steps=1, generators=[tq.paulis.Y(0)])
     H = tq.paulis.X(0)
     O = tq.ExpectationValue(U=U, H=H)
-    result = tq.minimize(method="lbfgs",objective=O, maxiter=20, backend=simulator, samples=10000)
+    result = tq.minimize(method="lbfgs",objective=O, maxiter=20, backend=simulator,
+                         samples=100, initial_values=numpy.pi/2)
     assert (numpy.isclose(result.energy, -1.0, atol=1.e-1))

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -20,7 +20,7 @@ def test_execution(simulator):
     H = 1.0 * tq.paulis.X(0) + 2.0 * tq.paulis.Y(1) + 3.0 * tq.paulis.Z(2)
     O = tq.ExpectationValue(U=U, H=H)
 
-    result = tq.optimizer_scipy.minimize(objective=O, maxiter=2, method="TNC", backend=simulator, silent=False)
+    result = tq.optimizer_scipy.minimize(objective=O, maxiter=2, method="TNC", backend=simulator, silent=True)
 
 
 @pytest.mark.parametrize("simulator", samplers)
@@ -37,7 +37,7 @@ def test_execution_shot(simulator):
     O = tq.ExpectationValue(U=U, H=H)
 
     result = tq.optimizer_scipy.minimize(objective=O, maxiter=2, method="TNC", backend=simulator, samples=3,
-                                         silent=False)
+                                         silent=True)
     assert (len(result.history.energies) <= 3)
 
 
@@ -46,7 +46,7 @@ def test_one_qubit_wfn(simulator):
     U = tq.gates.Trotterized(angles=["a"], steps=1, generators=[tq.paulis.Y(0)])
     H = tq.paulis.X(0)
     O = tq.ExpectationValue(U=U, H=H)
-    result = tq.optimizer_scipy.minimize(objective=O, maxiter=15, backend=simulator, silent=False)
+    result = tq.optimizer_scipy.minimize(objective=O, maxiter=15, backend=simulator, silent=True)
     assert (numpy.isclose(result.energy, -1.0))
 
 
@@ -56,7 +56,7 @@ def test_one_qubit_shot(simulator):
     H = tq.paulis.X(0)
     O = tq.ExpectationValue(U=U, H=H)
     samples = 1000
-    result = tq.minimize(objective=O, method="cobyla", backend=simulator, samples=samples, silent=False,
+    result = tq.minimize(objective=O, method="cobyla", backend=simulator, samples=samples, silent=True,
                          initial_values=-0.5)
     assert (numpy.isclose(result.energy, -1.0, atol=1.e-1))
 
@@ -75,7 +75,7 @@ def test_gradient_free_methods(simulator, method):
         return True
 
     result = tq.optimizer_scipy.minimize(objective=-E, method=method, tol=1.e-4, backend=simulator,
-                                         initial_values=initial_values, silent=False)
+                                         initial_values=initial_values, silent=True)
     assert (numpy.isclose(result.energy, -1.0, atol=1.e-1))
 
 
@@ -98,7 +98,7 @@ def test_gradient_based_methods(simulator, method, use_gradient):
     result = tq.optimizer_scipy.minimize(objective=-E, backend=simulator, gradient=use_gradient, method=method,
                                          tol=1.e-3,
                                          method_options={"gtol": 1.e-4, "eps": 1.e-4, "finite_diff_rel_step": 1.e-4},
-                                         initial_values=initial_values, silent=False)
+                                         initial_values=initial_values, silent=True)
     assert (numpy.isclose(result.energy, -1.0, atol=1.e-1))
 
 
@@ -117,7 +117,7 @@ def test_gradient_based_methods_qng(simulator, method):
     result = tq.optimizer_scipy.minimize(objective=-E, gradient='qng', backend=simulator,
                                          method=method, tol=1.e-3,
                                          method_options={"gtol": 1.e-3, "eps": 1.e-4},
-                                         initial_values=initial_values, silent=False)
+                                         initial_values=initial_values, silent=True)
     assert (numpy.isclose(result.energy, -0.612, atol=1.e-1))
 
 
@@ -147,5 +147,5 @@ def test_hessian_based_methods(simulator, method, use_hessian):
             return
 
     result = tq.optimizer_scipy.minimize(objective=-E, backend=simulator, hessian=use_hessian, method=method, tol=1.e-4,
-                                         method_options=method_options, initial_values=initial_values, silent=False)
+                                         method_options=method_options, initial_values=initial_values, silent=True)
     assert (numpy.isclose(result.energy, -1.0, atol=1.e-1))

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -20,7 +20,7 @@ def test_execution(simulator):
     H = 1.0 * tq.paulis.X(0) + 2.0 * tq.paulis.Y(1) + 3.0 * tq.paulis.Z(2)
     O = tq.ExpectationValue(U=U, H=H)
 
-    result = tq.optimizer_scipy.minimize(objective=O, maxiter=2, method="TNC", backend=simulator, silent=True)
+    result = tq.optimizer_scipy.minimize(objective=O, maxiter=2, method="TNC", backend=simulator, silent=False)
 
 
 @pytest.mark.parametrize("simulator", samplers)
@@ -37,7 +37,7 @@ def test_execution_shot(simulator):
     O = tq.ExpectationValue(U=U, H=H)
 
     result = tq.optimizer_scipy.minimize(objective=O, maxiter=2, method="TNC", backend=simulator, samples=3,
-                                         silent=True)
+                                         silent=False)
     assert (len(result.history.energies) <= 3)
 
 
@@ -46,7 +46,7 @@ def test_one_qubit_wfn(simulator):
     U = tq.gates.Trotterized(angles=["a"], steps=1, generators=[tq.paulis.Y(0)])
     H = tq.paulis.X(0)
     O = tq.ExpectationValue(U=U, H=H)
-    result = tq.optimizer_scipy.minimize(objective=O, maxiter=15, backend=simulator, silent=True)
+    result = tq.optimizer_scipy.minimize(objective=O, maxiter=15, backend=simulator, silent=False)
     assert (numpy.isclose(result.energy, -1.0))
 
 
@@ -75,7 +75,7 @@ def test_gradient_free_methods(simulator, method):
         return True
 
     result = tq.optimizer_scipy.minimize(objective=-E, method=method, tol=1.e-4, backend=simulator,
-                                         initial_values=initial_values, silent=True)
+                                         initial_values=initial_values, silent=False)
     assert (numpy.isclose(result.energy, -1.0, atol=1.e-1))
 
 
@@ -91,19 +91,14 @@ def test_gradient_based_methods(simulator, method, use_gradient):
     U += tq.gates.Ry(angle=tq.assign_variable("b") * numpy.pi, target=1, control=0)
     E = tq.ExpectationValue(H=H, U=U)
 
-    # need to improve starting points for some of the optimizations
-    initial_values = {"a": 0.002, "b": 0.01}
-    if method in ["L-BFGS-B", "TNC"]:
-        initial_values = {"a": 0.1, "b": 0.8}
-    if use_gradient is False:
-        initial_values = {"a": 0.3, "b": 0.8}
+    initial_values = {"a": 3.45, "b": 2.85}
 
     # eps is absolute finite difference step of scipy (used only for gradient = False or scipy < 1.5)
     # finite_diff_rel_step is relative step
     result = tq.optimizer_scipy.minimize(objective=-E, backend=simulator, gradient=use_gradient, method=method,
                                          tol=1.e-3,
                                          method_options={"gtol": 1.e-4, "eps": 1.e-4, "finite_diff_rel_step": 1.e-4},
-                                         initial_values=initial_values, silent=True)
+                                         initial_values=initial_values, silent=False)
     assert (numpy.isclose(result.energy, -1.0, atol=1.e-1))
 
 
@@ -117,15 +112,11 @@ def test_gradient_based_methods_qng(simulator, method):
     U += tq.gates.Ry('c', 1) + tq.gates.Rx('d', 2)
     U += tq.gates.CNOT(control=0, target=1) + tq.gates.CNOT(control=1, target=2)
     E = tq.ExpectationValue(H=H, U=U)
-    # just equal to the original circuit, but i'm checking that all the sub-division works
-    O = (4 / 8) * E + (3 / 8) * copy.deepcopy(E) + (1 / 8) * copy.deepcopy(E) + tq.Variable('a') - tq.Variable('a')
 
-    initial_values = {"a": 0.432, "b": -0.123, 'c': 0.543, 'd': 0.233}
-    if method in ['TNC', 'CG']:
-        ### these methods have to be babied to guarantee convergence
-        initial_values = {"a": 0.8, "b": 1.6, 'c': 0.9, 'd': -0.15}
-    result = tq.optimizer_scipy.minimize(objective=-O, gradient='qng', backend=simulator,
-                                         method=method, tol=1.e-4, method_options={"gtol": 1.e-4, "eps": 1.e-4},
+    initial_values = {"a": -0.01, "b": 1.60, 'c': 1.52, 'd': -0.53}
+    result = tq.optimizer_scipy.minimize(objective=-E, gradient='qng', backend=simulator,
+                                         method=method, tol=1.e-3,
+                                         method_options={"gtol": 1.e-3, "eps": 1.e-4},
                                          initial_values=initial_values, silent=False)
     assert (numpy.isclose(result.energy, -0.612, atol=1.e-1))
 
@@ -142,21 +133,19 @@ def test_hessian_based_methods(simulator, method, use_hessian):
     method_options = {"gtol": 1.e-4}
 
     # need to improve starting points for some of the optimizations
-    initial_values = {"a": 0.002, "b": 0.01}
+    initial_values = {"a": 0.45, "b": 0.98}
     if method not in ["TRUST-CONSTR", "TRUST_KRYLOV]"]:
         method_options['eta'] = 0.1
         method_options['initial_trust_radius'] = 0.1
         method_options['max_trust_radius'] = 0.25
         method_options["finite_diff_rel_step"] = 1.e-4
         method_options["eps"] = 1.e-4
-        initial_values = {"a": 0.3, "b": 0.8}
 
     # numerical hessian only works for this method
     if use_hessian in ['2-point', '3-point']:
         if method != "TRUST-CONSTR":
             return
-        initial_values = {"a": 0.3, "b": 0.8}
 
     result = tq.optimizer_scipy.minimize(objective=-E, backend=simulator, hessian=use_hessian, method=method, tol=1.e-4,
-                                         method_options=method_options, initial_values=initial_values, silent=True)
+                                         method_options=method_options, initial_values=initial_values, silent=False)
     assert (numpy.isclose(result.energy, -1.0, atol=1.e-1))


### PR DESCRIPTION
This mostly involved selecting parameters closer to optimal values in different optimization tests. This should be especially useful for testing some of the slower backends.

test_scipy could probably be pruned a bit still, some of the tests are probably not actually required...