### PR TITLE
Update the way a measurement is made

### DIFF
--- a/tutorials/BasicUsage.ipynb
+++ b/tutorials/BasicUsage.ipynb
@@ -323,6 +323,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Individual measurement instructions can be added over the `read_out_qubits` keyword"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "+1.0000|0> +5.0000|1> "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "compiled_circuit = tq.compile(circuit, samples=10, backend=\"qulacs\")\n",
+    "\n",
+    "compiled_circuit(samples=10, read_out_qubits=[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Create Parametrized Circuits\n",
     "\n",
     "Now we will explore how to create parametrized circuits.  \n",
@@ -335,20 +364,6 @@
     "If the circuit gets simulated the value of the variable has to be specified.  \n",
     "This is done by passing down a dictionary holding the names and values of all variables."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
In the tutorial BasicUsage.ipynb, measurement is outdated, in this change it is updated with the use of the read_out_qubits keyword