### PR TITLE
Fix a bug with read_out qubits using Qiskit and Qibo simulators

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy == 1.95
 scipy >= 1.5
 sympy
 jax

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy <= 1.8
+numpy <= 1.19
 scipy >= 1.5
 sympy
 jax

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy == 1.95
+numpy <= 1.95
 scipy >= 1.5
 sympy
 jax

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy <= 1.95
+numpy <= 1.8
 scipy >= 1.5
 sympy
 jax

--- a/src/tequila/simulators/simulator_qibo.py
+++ b/src/tequila/simulators/simulator_qibo.py
@@ -430,7 +430,7 @@ class BackendCircuitQibo(BackendCircuit):
         # todo there are faster ways
 
         for k, v in backend_result.frequencies(binary=True).items():
-            converted_key = BitString.from_bitstring(other=BitStringLSB.from_binary(binary=k))
+            converted_key = BitString.from_bitstring(other=BitString.from_binary(binary=k))
             result._state[converted_key] = v
 
 
@@ -678,6 +678,7 @@ class BackendCircuitQibo(BackendCircuit):
         -------
         None
         """
+        target_qubits = sorted(target_qubits)
         added=[]
         for t in target_qubits:
             circuit.add(gates.M(t))
@@ -736,4 +737,3 @@ class BackendCircuitQibo(BackendCircuit):
 
 class BackendExpectationValueQibo(BackendExpectationValue):
     BackendCircuitType = BackendCircuitQibo
-

--- a/src/tequila/utils/keymap.py
+++ b/src/tequila/utils/keymap.py
@@ -58,8 +58,8 @@ class KeyMapSubregisterToRegister(KeyMapABC):
         return self.make_complement()
 
     def __init__(self, subregister: typing.List[int], register: typing.List[int]):
-        self._subregister = subregister
-        self._register = register
+        self._subregister = sorted(subregister)
+        self._register = sorted(register)
 
     def make_complement(self):
         return [i for i in self._register if i not in self._subregister]

--- a/tests/test_simulator_backends.py
+++ b/tests/test_simulator_backends.py
@@ -355,3 +355,16 @@ def test_sampling(backend):
     for i in range(10):
         e = E(samples=1000)
         assert numpy.isclose(e, 0.0, atol=2.e-1)
+
+@pytest.mark.parametrize("backend", tequila.simulators.simulator_api.INSTALLED_SAMPLERS.keys())
+def test_sampling_read_out_qubits(backend):
+    U = tq.gates.X(0)
+    U += tq.gates.Z(1)
+
+    wfn = tq.QubitWaveFunction(2)
+
+    result = tq.simulate(U, backend=backend, samples=1, read_out_qubits=[0, 1])
+    assert (numpy.isclose(numpy.abs(wfn.inner(result)) ** 2, 1.0, atol=1.e-4))
+
+    result = tq.simulate(U, backend=backend, samples=1, read_out_qubits=[1, 0])
+    assert (numpy.isclose(numpy.abs(wfn.inner(result)) ** 2, 1.0, atol=1.e-4))


### PR DESCRIPTION
The order you specify the `read_out_qubits` should not matter.
A minimal example replicating the issue:
```python
simulator = 'qiskit'

qc  = tq.gates.X(0)
qc += tq.gates.Z(1)

result = tq.simulate(qc, backend=simulator, samples=1, read_out_qubits=[0, 1])
print(result)
---
Output: +1.0000|10> 

result = tq.simulate(qc, backend=simulator, samples=1, read_out_qubits=[1, 0])
print(result)
---
Output: +1.0000|01> 
```

Similar with Qibo:
```python
simulator = 'qibo'

qc  = tq.gates.X(0)
qc += tq.gates.Z(1)

result = tq.simulate(qc, backend=simulator, samples=1, read_out_qubits=[0, 1])
print(result)
---
Output: +1.0000|01> 

result = tq.simulate(qc, backend=simulator, samples=1, read_out_qubits=[1, 0])
print(result)
---
Output: +1.0000|10> 
```

Expected result is `+1.0000|10>`.