### PR TITLE
PR:PySCF

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Currently you need to compile from a separate [fork](https://github.com/kottmanj
 See the github page of this fork for installation instruction.
 Here is a small [tutorial](https://github.com/aspuru-guzik-group/tequila-tutorials/blob/main/ChemistryMadnessInterface.ipynb) that illustrates the usage.
 
+- [PySCF](https://github.com/pyscf/pyscf)  
+Works similar as Psi4. Classical methods are also integrated in the madness interface allowing to use them in a basis-set-free representation.
+
 # Install from source
 **Do not** install like this: (Minecraft lovers excluded)
 <strike>`pip install tequila`</strike>

--- a/src/tequila/quantumchemistry/__init__.py
+++ b/src/tequila/quantumchemistry/__init__.py
@@ -62,6 +62,8 @@ def Molecule(geometry: str,
 
     parameters = ParametersQC(geometry=geometry, basis_set=basis_set, multiplicity=1, **keyvals)
 
+    integrals_provided = all([key in kwargs for key in ["one_body_integrals", "two_body_integrals"]])
+
     if backend is None:
         if basis_set is None or basis_set.lower() in ["madness", "mra", "pno"]:
             backend = "madness"
@@ -72,8 +74,7 @@ def Molecule(geometry: str,
         else:
             raise Exception("No quantum chemistry backends installed on your system")
     elif backend == "base":
-            requirements = [key in kwargs for key in ["one_body_integrals", "two_body_integrals"]]
-            if not all(requirements):
+            if not integrals_provided:
                 raise Exception("No quantum chemistry backends installed on your system\n"
                             "To use the base functionality you need to pass the following tensors via keyword\n"
                             "one_body_integrals, two_body_integrals\n")
@@ -89,8 +90,8 @@ def Molecule(geometry: str,
     if guess_wfn is not None and backend != 'psi4':
         raise Exception("guess_wfn only works for psi4")
 
-    if basis_set is None and backend.lower() not in  ["base", "madness"]:
-        raise Exception("no basis_set provided for backend={}".format(backend))
+    if basis_set is None and backend.lower() not in  ["base", "madness"] and not integrals_provided:
+        raise Exception("no basis_set or integrals provided for backend={}".format(backend))
     elif basis_set is None:
         basis_set = "custom"
         parameters.basis_set=basis_set


### PR DESCRIPTION
Better support for standard basis-sets with PySCF (as an alternative to Psi4)