### PR TITLE
PR pyscf hotfix

### DIFF
--- a/.github/workflows/ci_chemistry.yml
+++ b/.github/workflows/ci_chemistry.yml
@@ -98,6 +98,7 @@ jobs:
         python -m pip install -r requirements.txt
         python -m pip install -e .
         python -m pip install pyscf
+        python -m pip install 'h5py <= 3.2.1'
         cd tests
         ls
         pytest test_chemistry.py

--- a/.github/workflows/ci_chemistry.yml
+++ b/.github/workflows/ci_chemistry.yml
@@ -98,7 +98,7 @@ jobs:
         python -m pip install -r requirements.txt
         python -m pip install -e .
         python -m pip install pyscf
-        python -m pip install 'h5py <= 3.2.1'
+        python -m pip install 'h5py <= 3.1'
         cd tests
         ls
         pytest test_chemistry.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,5 @@ qulacs # default simulator (best integration), remove if the installation gives 
 
 #optional third party libraries
 #pyzx
-
+#pyscf # if used also restrict h5py version untill the issue is fixed upstream in pyscf
+#h5py <= 3.2.1 # version 3.3.0 leads to crashes when pyscf is imported

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ qulacs # default simulator (best integration), remove if the installation gives 
 #optional third party libraries
 #pyzx
 #pyscf # if used also restrict h5py version untill the issue is fixed upstream in pyscf
-#h5py <= 3.2.1 # version 3.3.0 leads to crashes when pyscf is imported
+#h5py <= 3.1 # version 3.3.0 leads to crashes when pyscf is imported


### PR DESCRIPTION
Prevent crashes when importing pyscf resulting from newest release of h5py